### PR TITLE
Fix command prefix on production

### DIFF
--- a/src/interaction-handler.ts
+++ b/src/interaction-handler.ts
@@ -15,7 +15,9 @@ export class InteractionHandler {
     return guild.commands.set(
       commands.map((command) => ({
         ...command,
-        name: `${this.config.get('DISCORD_PREFIX')}_${command.name}`,
+        name: this.config.get('DISCORD_PREFIX')
+          ? `${this.config.get('DISCORD_PREFIX')}_${command.name}`
+          : command.name,
       }))
     );
   }


### PR DESCRIPTION
- Proper check when prefix is missing (currently on production environments).