### PR TITLE
 Play next song on socket error

### DIFF
--- a/src/music-player.ts
+++ b/src/music-player.ts
@@ -48,7 +48,7 @@ export class MusicPlayer {
   playYoutubeVideo(url: string) {
     const stream = ytdl(url, {
       filter: 'audioonly',
-      quality: 'highestaudio',
+      quality: 'lowest',
     });
     const resource = createAudioResource(stream, {
       inputType: StreamType.Arbitrary,

--- a/src/music-queue.ts
+++ b/src/music-queue.ts
@@ -1,3 +1,4 @@
+import { AudioPlayerError } from '@discordjs/voice';
 import { singleton } from 'tsyringe';
 import { MusicPlayer } from './music-player';
 
@@ -19,8 +20,10 @@ export class MusicQueue {
     // FIXME: Potential infinite loop,
     // when sending invalid resource instead of handling network error.
     this.musicPlayer.audioPlayerErrorCallback = (error) => {
-      console.log('Trying to restore music after audio disconnect.', error);
-      this.musicPlayer.currentSubscription?.player.play(error.resource);
+      if (error instanceof AudioPlayerError && error.message === 'aborted') {
+        console.warn('Audio played disconnected, playing next sond.', error);
+        this.musicPlayer.currentSubscription?.player.play(error.resource);
+      }
     };
   }
 

--- a/src/music-queue.ts
+++ b/src/music-queue.ts
@@ -33,7 +33,7 @@ export class MusicQueue {
   }
 
   updateQueue() {
-    if (this.size() === 0) return this.musicPlayer.disconnect();
+    if (this.size() === 0) return;
 
     if (this.nowPlaying == null) {
       console.log('Playing next song');


### PR DESCRIPTION
- Instead of trying to replay the current audio resource (which has already ended [1]), skip to next song in queue. 
- _minor:_ Don't disconnect bot immediately from voice channel on last sond ending

Related open issues to the Error:

- https://github.com/fent/node-ytdl-core/issues/902
- https://github.com/discordjs/voice/issues/195
- https://github.com/discordjs/voice/issues/196

[1] 
```
Error: Cannot play a resource that has already ended.
at AudioPlayer.play (/app/node_modules/@discordjs/voice/dist/audio/AudioPlayer.js:194:19)
```