### PR TITLE
Song info fetching and additional info in show-queue command

### DIFF
--- a/src/command-handlers/play-handler.ts
+++ b/src/command-handlers/play-handler.ts
@@ -49,7 +49,8 @@ export class PlayHandler implements CommandHandler {
     if (songQuery == null)
       return interaction.reply('Song query must not be empty.');
 
+    await interaction.deferReply();
     const song = await this.groobyBot.queueSong(songQuery);
-    await interaction.reply(`E sviram ${song}`);
+    await interaction.editReply(`Ja kladov ${song.url}`);
   }
 }

--- a/src/command-handlers/show-queue.ts
+++ b/src/command-handlers/show-queue.ts
@@ -13,10 +13,15 @@ export class ShowQueueHandler implements CommandHandler<CommandInteraction> {
   constructor(private musicQueue: MusicQueue) {}
 
   async handle(command: Command<CommandInteraction>) {
-    const queue = [this.musicQueue.nowPlaying, ...this.musicQueue.queue];
+    const queue = this.musicQueue.nowPlaying
+      ? [this.musicQueue.nowPlaying, ...this.musicQueue.queue]
+      : this.musicQueue.queue;
 
-    await command.payload.reply(
-      `Sviram: ${queue.map((song, index) => `\n ${index + 1}. ${song?.url}`)}`
-    );
+    await command.payload.reply({
+      content: `Sviram: ${queue.map(
+        (song, index) => `\n ${index + 1}. ${song?.name} \n\t\t(<${song?.url}>)`
+      )}`,
+      embeds: [],
+    });
   }
 }

--- a/src/grooby-bot.ts
+++ b/src/grooby-bot.ts
@@ -30,15 +30,11 @@ export class GroobyBot {
   }
 
   async queueSong(query: string) {
-    const youtubeUrl = await this.youtubeService.parse(query);
+    const youtubeTrack = await this.youtubeService.parse(query);
 
-    this.musicQueue.push(
-      new Track(
-        youtubeUrl ? youtubeUrl : 'https://youtube.com/watch?v=Zffe_CsJQSA'
-      )
-    );
+    this.musicQueue.push(youtubeTrack);
 
-    return youtubeUrl;
+    return youtubeTrack;
   }
 
   /**


### PR DESCRIPTION
- Use the `Track` concept for working with queued songs
- Use `ytdl` helper function for checking if URL is valid youtube url
- Use `ytdl` for song info fetching
- Expand `ShowQueueHandler ` to utilize newely fetch track name as well

TODO
- [ ] Optimize the double API call for song info (first YT search API for URL, then `ytdl.showInfo`
  - Extract Track info directly from API
  - Remove  `await interaction.deferReply();` if it speeds the reply enough (should do it, as we are back to same behaviour as previously)